### PR TITLE
extract two

### DIFF
--- a/extract2reads.R
+++ b/extract2reads.R
@@ -1,0 +1,35 @@
+#This is a program to assess MiSeq count tables from MOTHUR
+
+library(dplyr) #load dplyr 
+
+out_table = NULL #initiate empty data frame
+#read_table = NULL
+
+files<-list.files() #create list of all files in the working directory
+#x<-length(files) #calculate the number of files in the working directory
+
+for (i in files) {
+  
+  t<-read.table(i,header=TRUE) #read file
+  t_sort<-arrange(t,desc(total)) #sort table by total read counts, largest first
+  t_ratio1<-t_sort[2,2]/t_sort[1,2] #calculate ratio btwn first and second largest read counts (btwn 0 and 1)
+  t_ratio2<-t_sort[3,2]/t_sort[1,2] #calculate ratio btwn first and third largest read counts (btwn 0 and 1)
+  t_totreads<-sum(t$total) #calculate the total read number in this well
+  y<-abbreviate(i,minlength=6) #truncate file name to get the well name
+  diff<-(t_ratio1-t_ratio2)/t_ratio1 #difference between the two ratios
+  
+  out_table<-rbind(out_table, data.frame(t_sort[1,1],t_sort[2,1],t_sort[1,2],t_ratio1,t_ratio2,diff,t_totreads,i,y)) #create table for output and bind to empty frame
+  #read_table<-rbind(read_table,data.frame(t_sort[1,1],t_sort[2,1],y))
+}
+
+
+colnames(out_table)<-c("read1","read2","count","ratio1","ratio2","diff","total","file","well") #rename columns for graph
+#colnames(read_table)<-c("read1","read2","well")
+
+#plot(out_table$well,out_table$ratio, ylim=c(0,1),xlab=("well"),ylab=("Ratio")) #graph of the ratio variable for each well
+
+z<-arrange(out_table,desc(total)) #sort output table by decreasing total
+head(z) #print first lines of sorted table
+#head(read_table)
+
+#Then use write.table function to output table as txt file for further use

--- a/extract2sequences.R
+++ b/extract2sequences.R
@@ -1,0 +1,25 @@
+#This is a program that takes a list of read names and well names and creates a fasta file of the reads we want for a single locus.
+#input: text file with list of reads and well names associated
+#for now, header on text file needs to read "name" and "well"
+#also need working directory to contain all fasta files for a locus (.unique are best b/c smallest)
+#NB: will break if the names of the wells are not represented in the file list
+
+library (seqinr) #load seqinr
+
+goodreads<-read.table("F:/phred35/good_reads/olon_1972_het.txt",header=TRUE) #read in list of names we need; to change each time the file changes
+files<-list.files() #make a list of all files in the working directory
+seq_out_table = NULL #initialize empty data frame
+
+for (i in goodreads$well) {
+  namelist<-grep(i,files, value=TRUE) #find filethat matches the well (works b/c file names start w/ well names)
+  namefasta<-read.fasta(namelist,as.string=TRUE,set.attributes=FALSE) #read the appropriate fasta
+  y<-cbind(namefasta[names(namefasta) %in% goodreads$read1],i) #extract the read in the fasta which matches the read name in the text file, bind with well name
+  z<-cbind(namefasta[names(namefasta) %in% goodreads$read2],i) #extract the second read for the well
+  seq_out_table<-rbind(seq_out_table,y,z ) #create output table of sequences and well names 
+  
+}
+
+colnames(seq_out_table)<-c("read","well") #rename columns on output table; prob not needed
+
+write.fasta(seq_out_table[,1],names=seq_out_table[,2],"F:/phred35/out_fasta/olon_1972_hetout.fasta") 
+#command to save to fasta with sequences and well names; change file name for each locus


### PR DESCRIPTION
Based on the MOTHUR counttables and extractseqs scripts, but will pull info for the first two lines of a counttable and calculate appropriate ratios, then pull two reads from the .unique.fasta files. Plan to use for diploid loci.
